### PR TITLE
fix: fix `setRect` to compute inherited rotate degrees

### DIFF
--- a/packages/ui-design-tool/renderer/components/InteractionController/interactions/useRotateFunctions.tsx
+++ b/packages/ui-design-tool/renderer/components/InteractionController/interactions/useRotateFunctions.tsx
@@ -84,9 +84,7 @@ export default function useRotateFunctions() {
       const handleCoordDegrees = rotateHandleCoordDegreesRef.current;
 
       const newRect =
-        handleCoordDegrees != null
-          ? calcRotatedRect(initialRect, (record as RotatableUIRecord).rotate.degrees, offsetPoint, handleCoordDegrees, { precision })
-          : initialRect;
+        handleCoordDegrees != null ? calcRotatedRect(initialRect, offsetPoint, handleCoordDegrees, { precision }) : initialRect;
 
       if (!isEqual(newRect.toJSON(), lastRect?.toJSON())) {
         setRef(transformLastRectRef, newRect);

--- a/packages/ui-design-tool/renderer/components/InteractionController/utils/rect.ts
+++ b/packages/ui-design-tool/renderer/components/InteractionController/utils/rect.ts
@@ -135,7 +135,6 @@ interface CalcRotatedRectOptions {
 
 export const calcRotatedRect = (
   rect: UIRecordRect,
-  rotate: number,
   mousePoint: { x: number; y: number },
   handleCoordDegrees: number,
   options: CalcRotatedRectOptions = {},
@@ -144,7 +143,6 @@ export const calcRotatedRect = (
 
   const fixValue = precision ? (value: number) => value : (value: number) => Math.round(value);
 
-  // rect.rotate는 조상을 포함해 계산된 값이므로, rotate를 사용함
   const newRectInit: UIRecordRectInit = pick(rect, ['x', 'y', 'width', 'height', 'rotate']);
 
   let newRotate = calcDegreesBetweenCoords(
@@ -155,10 +153,11 @@ export const calcRotatedRect = (
     mousePoint,
   );
   newRotate -= handleCoordDegrees;
-  newRotate += rotate;
+  newRotate += rect.rotate;
   newRotate = fixValue(newRotate);
+  newRotate = toDegrees360(newRotate);
 
-  newRectInit.rotate = toDegrees360(newRotate);
+  newRectInit.rotate = newRotate;
 
   return UIRecordRect.fromRect(newRectInit);
 };

--- a/packages/utils/src/findLinked.ts
+++ b/packages/utils/src/findLinked.ts
@@ -1,4 +1,4 @@
-export interface findLinkedOptions {
+export interface FindLinkedOptions {
   self?: boolean;
 }
 
@@ -15,19 +15,19 @@ function findLinked<T extends object>(
   item: T | undefined,
   prop: Prop<T> | GetProp<T>,
   predicate: Predicate<T>,
-  options?: findLinkedOptions,
+  options?: FindLinkedOptions,
 ): T | undefined;
 function findLinked<T extends object, R extends object>(
   item: T | undefined,
   prop: PropWithResult<T, R> | GetPropWithResult<T, R>,
   predicate: PredicateWithResult<T, R>,
-  options?: findLinkedOptions,
+  options?: FindLinkedOptions,
 ): R | undefined;
 function findLinked<T extends object, R extends object = T>(
   item: T | undefined,
   prop: PropWithResult<T, R> | GetPropWithResult<T, R>,
   predicate: PredicateWithResult<T, R>,
-  options: findLinkedOptions = {},
+  options: FindLinkedOptions = {},
 ): R | undefined {
   const { self = false } = options;
 

--- a/packages/utils/src/index.ts
+++ b/packages/utils/src/index.ts
@@ -35,6 +35,7 @@ export { default as omitBy } from 'lodash-es/omitBy';
 export { default as pascalCase } from './pascalCase';
 export { default as pick } from 'lodash-es/pick';
 export { default as pickBy } from 'lodash-es/pickBy';
+export { default as reduceLinked } from './reduceLinked';
 export { default as snakeCase } from 'lodash-es/snakeCase';
 export { default as toCorrectFloat } from './toCorrectFloat';
 export { default as toDegrees } from './toDegrees';

--- a/packages/utils/src/reduceLinked.ts
+++ b/packages/utils/src/reduceLinked.ts
@@ -1,0 +1,53 @@
+export interface ReduceLinkedOptions<T = undefined> {
+  self?: boolean;
+  initialValue?: T;
+}
+
+type Prop<T> = keyof T;
+
+type GetProp<T> = (value?: T) => Prop<T>;
+
+type Reducer<T, R> = (accumulator: R, value: T) => R;
+
+function reduceLinked<T extends object>(
+  item: T | undefined,
+  prop: Prop<T> | GetProp<T>,
+  reducer: Reducer<T, T>,
+  options?: ReduceLinkedOptions<T>,
+): T | undefined;
+function reduceLinked<T extends object, U>(
+  item: T | undefined,
+  prop: Prop<T> | GetProp<T>,
+  reducer: Reducer<T, U>,
+  options: ReduceLinkedOptions<U>,
+): 'initialValue' extends keyof typeof options ? U : U | undefined;
+function reduceLinked<T extends object, U = T>(
+  item: T | undefined,
+  prop: Prop<T> | GetProp<T>,
+  reducer: Reducer<T, U>,
+  options: ReduceLinkedOptions<U> = {},
+): 'initialValue' extends keyof typeof options ? U : U | undefined {
+  const { self = false, initialValue } = options;
+
+  const getNext = (current?: T) => {
+    const key = typeof prop === 'function' ? prop(current) : prop;
+    return current?.[key as keyof typeof current] as T;
+  };
+
+  let accumulator: U | undefined = initialValue;
+  let current = self ? item : getNext(item);
+
+  while (true) {
+    if (current == null || typeof current !== 'object') {
+      return accumulator as 'initialValue' extends keyof typeof options ? U : U | undefined;
+    }
+    if (accumulator === undefined) {
+      accumulator = current as unknown as U;
+    } else {
+      accumulator = reducer(accumulator, current);
+    }
+    current = getNext(current);
+  }
+}
+
+export default reduceLinked;

--- a/packages/utils/tests/findLinked.test.ts
+++ b/packages/utils/tests/findLinked.test.ts
@@ -8,28 +8,28 @@ interface Person {
 
 describe('findLinked', () => {
   const grandFather: Person = {
-    name: '최최최',
+    name: '할아버지',
   };
   const father: Person = {
-    name: '최최',
+    name: '아빠',
     father: grandFather,
   };
   const mother: Person = {
-    name: '권권',
+    name: '엄마',
   };
   const me: Person = {
-    name: '최',
+    name: '나',
     father,
     mother,
   };
 
   test('should find linked object with property and predicate', () => {
-    const result = findLinked(me, 'father', (person) => person.name === '최최');
+    const result = findLinked(me, 'father', (person) => person.name === '아빠');
     expect(result).toBe(father);
   });
 
   test('should return undefined if no linked object matches predicate', () => {
-    const result = findLinked(me, 'father', (person) => person.name === '권권');
+    const result = findLinked(me, 'father', (person) => person.name === '엄마');
     expect(result).toBeUndefined();
   });
 
@@ -39,23 +39,23 @@ describe('findLinked', () => {
   });
 
   test('should find linked object itself with self option', () => {
-    const result = findLinked(me, 'father', (person) => person.name === '최', { self: true });
+    const result = findLinked(me, 'father', (person) => person.name === '나', { self: true });
     expect(result).toBe(me);
   });
 
   test('should return undefined if find itself without self option', () => {
-    const result = findLinked(me, 'father', (person) => person.name === '최');
+    const result = findLinked(me, 'father', (person) => person.name === '나');
     expect(result).toBeUndefined();
   });
 
   test('should find deep linked object', () => {
-    const result = findLinked(me, 'father', (person) => person.name === '최최최');
+    const result = findLinked(me, 'father', (person) => person.name === '할아버지');
     expect(result).toBe(grandFather);
   });
 
   test('should find linked object with property getter and predicate', () => {
     const getParent = (person?: Person) => (person?.mother ? 'mother' : 'father');
-    const result = findLinked(me, getParent, (person) => person.name === '권권');
+    const result = findLinked(me, getParent, (person) => person.name === '엄마');
     expect(result).toBe(mother);
   });
 });

--- a/packages/utils/tests/reduceLinked.test.ts
+++ b/packages/utils/tests/reduceLinked.test.ts
@@ -1,0 +1,46 @@
+import reduceLinked from '@/src/reduceLinked';
+
+interface Person {
+  name: string;
+  mother?: Person;
+  father?: Person;
+}
+
+describe('reduceLinked', () => {
+  const grandFather: Person = {
+    name: '할아버지',
+  };
+  const father: Person = {
+    name: '아빠',
+    father: grandFather,
+  };
+  const mother: Person = {
+    name: '엄마',
+  };
+  const me: Person = {
+    name: '나',
+    father,
+    mother,
+  };
+
+  test('should reduce linked object with property and reducer', () => {
+    const result = reduceLinked(me, 'father', (acc, person) => ({ ...acc, name: acc.name + person.name }));
+    expect(result.name).toBe('아빠할아버지');
+  });
+
+  test('should reduce linked object itself with self option', () => {
+    const result = reduceLinked(me, 'father', (acc, person) => ({ ...acc, name: acc.name + person.name }), { self: true });
+    expect(result.name).toBe('나아빠할아버지');
+  });
+
+  test('should reduce deep linked object', () => {
+    const result = reduceLinked(me, 'father', (acc, person) => ({ ...acc, name: acc.name + person.name + '조상님' }));
+    expect(result.name).toBe('아빠할아버지조상님');
+  });
+
+  test('should reduce linked object with property getter and reducer', () => {
+    const getParent = (person?: Person) => (person?.mother ? 'mother' : 'father');
+    const result = reduceLinked(me, getParent, (acc, person) => ({ ...acc, name: acc.name + person.name }));
+    expect(result.name).toBe('엄마');
+  });
+});


### PR DESCRIPTION
###### Commit message body
<!--
Commit message body를 작성하세요.
Commit message subject는 Pull request title 필드에 작성하세요.
-->

```txt
and:
- feat(utils): add `reduceLinked` util function
```

## Description
<!--
변경 사항에 대한 요약을 작성하세요.
작업의 목적과 의도 등 맥락이 충분히 포함되어야 합니다.
재현하기 어려운 버그를 수정한 경우 재현 시나리오도 함께 작성하세요.
관련 이슈가 있다면 키워드 또는 사이드바를 사용해 연결하세요.
https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue
-->

인터랙션 발생 시, 조상 UIRecord의 회전 각도를 고려하지 않아 잘못된 각도가 적용되는 버그를 수정했습니다. 
`UIDesignTool.setRect` 메서드 내에서 부모 UIRecord를 탐색해 `rotate.degrees` 값을 더하고자, `reduceLinked` 함수를 구현했습니다.

## Checklist
<!--
PR이 병합되기 전에 검토해야 하는 체크리스트를 작성하고 확인하세요.
-->

- [x] 모든 변경 사항이 스타일 가이드를 따르고, lint·format 스크립트를 통과했습니다.
- [x] 변경 사항에 대한 테스트 코드를 작성하고, test 스크립트를 통과했습니다.
